### PR TITLE
disable default kill indicator / spelling

### DIFF
--- a/ModernWarfareHUD/Scripts/MWHUD_ScoreSystem.lua
+++ b/ModernWarfareHUD/Scripts/MWHUD_ScoreSystem.lua
@@ -5,7 +5,15 @@ function MWHUD_ScoreSystem:Start()
 	-- Run when behaviour is created
 
 	self.systemEnabled = self.script.mutator.GetConfigurationBool("scoreSystemEnabled")
-
+	
+	if self.script.mutator.GetConfigurationBool("scoreSystemEnabled") == true then
+	--Disable Ingame Kill Indicators though that can be done in the games' settings lol
+	GameObject.Find("Kill Indicator (1)").gameObject.SetActive(false)
+	GameObject.Find("Kill Indicator (2)").gameObject.SetActive(false)
+	GameObject.Find("Kill Indicator").gameObject.SetActive(false)
+	GameObject.Find("Kill Indicator Parent Panel").gameObject.SetActive(false)
+	end
+	
 	self.totalPoints = 0
 	self.streakPoints = 0
 

--- a/ModernWarfareHUD/Scripts/MWHUD_ScoreSystem.lua
+++ b/ModernWarfareHUD/Scripts/MWHUD_ScoreSystem.lua
@@ -109,7 +109,7 @@ function MWHUD_ScoreSystem:onActorDied(actor, source, isSilent)
 			else
 				bonus = bonus + 25
 				if message == "" then
-					message = "Offenseive Kill!"
+					message = "Offensive Kill!"
 				else
 					message = message .. "\nOffense Kill!"
 				end

--- a/ModernWarfareHUD/Scripts/MWHUD_ScoreSystem.lua
+++ b/ModernWarfareHUD/Scripts/MWHUD_ScoreSystem.lua
@@ -5,15 +5,7 @@ function MWHUD_ScoreSystem:Start()
 	-- Run when behaviour is created
 
 	self.systemEnabled = self.script.mutator.GetConfigurationBool("scoreSystemEnabled")
-	
-	if self.script.mutator.GetConfigurationBool("scoreSystemEnabled") == true then
-	--Disable Ingame Kill Indicators though that can be done in the games' settings lol
-	GameObject.Find("Kill Indicator (1)").gameObject.SetActive(false)
-	GameObject.Find("Kill Indicator (2)").gameObject.SetActive(false)
-	GameObject.Find("Kill Indicator").gameObject.SetActive(false)
-	GameObject.Find("Kill Indicator Parent Panel").gameObject.SetActive(false)
-	end
-	
+
 	self.totalPoints = 0
 	self.streakPoints = 0
 
@@ -39,6 +31,11 @@ function MWHUD_ScoreSystem:Start()
 		GameEvents.onCapturePointCaptured.AddListener(self,"onCapturePointCaptured")
 		GameEvents.onCapturePointNeutralized.AddListener(self,"onCapturePointNeutralized")
 		GameEvents.onMatchEnd.AddListener(self,"onMatchEnd")
+		--Disable Ingame Kill Indicators though that can be done in the games' settings lol
+		GameObject.Find("Kill Indicator (1)").gameObject.SetActive(false)
+		GameObject.Find("Kill Indicator (2)").gameObject.SetActive(false)
+		GameObject.Find("Kill Indicator").gameObject.SetActive(false)
+		GameObject.Find("Kill Indicator Parent Panel").gameObject.SetActive(false)
 		print("<color=lime>[MW HUD]Initialized Score System v1.0.0</color>")
 	end
 end


### PR DESCRIPTION
disables ravenfield's default KILLED <Bot> when score system is enabled
also fixed spelling